### PR TITLE
sort file list for deterministic behavior

### DIFF
--- a/torch_skeleton/datasets/ntu.py
+++ b/torch_skeleton/datasets/ntu.py
@@ -75,7 +75,7 @@ class NTU(Dataset):
             missing_files = f.read().splitlines()[3:]
         paths = filter_missing(paths, missing_files)
 
-        self.file_paths = paths
+        self.file_paths = sorted(paths)
 
     def __getitem__(self, index):
         path = self.file_paths[index]

--- a/torch_skeleton/datasets/ucla.py
+++ b/torch_skeleton/datasets/ucla.py
@@ -39,7 +39,7 @@ class UCLA(Dataset):
             skel_utils.extract_zip(path, self.root)
 
         paths = skel_utils.listdir(self.root, ext="json")
-        self.file_paths = filter_split(paths, split)
+        self.file_paths = sorted(filter_split(paths, split))
 
     def __getitem__(self, index):
         path = self.file_paths[index]


### PR DESCRIPTION
Currently `listdir()` causes different file list order on different machines. By sorting the file list based on their paths we can guarantee the orders of the files will be same across different machines.